### PR TITLE
Handle empty revision links better

### DIFF
--- a/ftl/util.go
+++ b/ftl/util.go
@@ -37,7 +37,7 @@ func (ri *RevisionInfo) Name() string {
 }
 
 type RevisionListResult struct {
-	Revisions []RevisionInfo
+	Revisions []*RevisionInfo
 	Err       error
 }
 

--- a/main_test.go
+++ b/main_test.go
@@ -1,24 +1,24 @@
 package main
 
 import (
-	"testing"
 	"github.com/rhettg/ftl/ftl"
+	"testing"
 )
 
 func Test_syncPackage_downNone(t *testing.T) {
-	rr := []ftl.RevisionInfo{
+	rr := []*ftl.RevisionInfo{
 		{"test", "001"},
 		{"test", "002"},
 		{"test", "003"},
 	}
 
-	lr := []ftl.RevisionInfo{
+	lr := []*ftl.RevisionInfo{
 		{"test", "001"},
 		{"test", "002"},
 		{"test", "003"},
 	}
 
-	download, purge, err := syncPackage(rr, lr, ftl.RevisionInfo{"test", "001"})
+	download, purge, err := syncPackage(rr, lr, &ftl.RevisionInfo{"test", "001"})
 	if err != nil {
 		t.Error("Error from syncPackage", err)
 	}
@@ -31,18 +31,45 @@ func Test_syncPackage_downNone(t *testing.T) {
 	}
 }
 
-func Test_syncPackage_downMore(t *testing.T) {
-	rr := []ftl.RevisionInfo{
+func Test_syncPackage_downSome(t *testing.T) {
+	rr := []*ftl.RevisionInfo{
 		{"test", "001"},
 		{"test", "002"},
 		{"test", "003"},
 	}
 
-	lr := []ftl.RevisionInfo{
+	lr := []*ftl.RevisionInfo{}
+
+	download, purge, err := syncPackage(rr, lr, &ftl.RevisionInfo{"test", "002"})
+	if err != nil {
+		t.Error("Error from syncPackage", err)
+	}
+
+	if len(download) != 2 {
+		t.Error("Expected two downloads")
+	}
+
+	if len(purge) > 0 {
+		t.Error("Expected no purges")
+	}
+
+	if download[0].Revision != "002" {
+		t.Error("Expected 002", download)
+	}
+}
+
+func Test_syncPackage_downMore(t *testing.T) {
+	rr := []*ftl.RevisionInfo{
+		{"test", "001"},
+		{"test", "002"},
+		{"test", "003"},
+	}
+
+	lr := []*ftl.RevisionInfo{
 		{"test", "002"},
 	}
 
-	download, purge, err := syncPackage(rr, lr, ftl.RevisionInfo{"test", "001"})
+	download, purge, err := syncPackage(rr, lr, &ftl.RevisionInfo{"test", "001"})
 	if err != nil {
 		t.Error("Error from syncPackage", err)
 	}
@@ -61,17 +88,17 @@ func Test_syncPackage_downMore(t *testing.T) {
 }
 
 func Test_syncPackage_downMoreLimit(t *testing.T) {
-	rr := []ftl.RevisionInfo{
+	rr := []*ftl.RevisionInfo{
 		{"test", "001"},
 		{"test", "002"},
 		{"test", "003"},
 	}
 
-	lr := []ftl.RevisionInfo{
+	lr := []*ftl.RevisionInfo{
 		{"test", "002"},
 	}
 
-	download, purge, err := syncPackage(rr, lr, ftl.RevisionInfo{"test", "002"})
+	download, purge, err := syncPackage(rr, lr, &ftl.RevisionInfo{"test", "002"})
 	if err != nil {
 		t.Error("Error from syncPackage", err)
 	}
@@ -90,16 +117,16 @@ func Test_syncPackage_downMoreLimit(t *testing.T) {
 }
 
 func Test_syncPackage_purgeOne(t *testing.T) {
-	rr := []ftl.RevisionInfo{
+	rr := []*ftl.RevisionInfo{
 		{"test", "002"},
 	}
 
-	lr := []ftl.RevisionInfo{
+	lr := []*ftl.RevisionInfo{
 		{"test", "001"},
 		{"test", "002"},
 	}
 
-	download, purge, err := syncPackage(rr, lr, ftl.RevisionInfo{"test", "001"})
+	download, purge, err := syncPackage(rr, lr, &ftl.RevisionInfo{"test", "001"})
 	if err != nil {
 		t.Error("Error from syncPackage", err)
 	}


### PR DESCRIPTION
Fixes issue with handling missing previous or current revision links by
using RevisionInfo pointers internally and comparing against nil.
